### PR TITLE
feat: add sw64 architecture support to compose packages

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+appstream (1.0.5-1deepin2) unstable; urgency=medium
+
+  * Add sw64 architecture support to compose packages
+  * Enable compose support on sw64 in debian/rules
+  * Add sw64 to appstream-compose, libappstream-compose0,
+    libappstream-compose-dev, gir1.2-appstreamcompose-1.0 Architecture
+    in debian/control
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 22 Jul 2026 17:31:55 +0800
+
 appstream (1.0.5-1deepin1) unstable; urgency=medium
 
   * Skip building doc package on architectures without compose support (e.g., sw64)

--- a/debian/control
+++ b/debian/control
@@ -19,7 +19,7 @@ Build-Depends: debhelper-compat (= 13),
                libglib2.0-dev (>= 2.62),
                libjs-highlight.js,
                libpango1.0-dev,
-               librsvg2-dev (>= 2.48) [amd64 arm64 armel armhf i386 loong64 mips64el mipsel ppc64el s390x powerpc ppc64 riscv64 sparc64 x32],
+               librsvg2-dev (>= 2.48) [amd64 arm64 armel armhf i386 loong64 mips64el mipsel ppc64el s390x powerpc ppc64 riscv64 sparc64 x32 sw64],
                libstemmer-dev,
                libsystemd-dev (>= 242) [linux-any],
                libxml2-dev,
@@ -61,7 +61,7 @@ Description: Software component metadata management
  validating it for compliance with the specification.
 
 Package: appstream-compose
-Architecture: amd64 arm64 armel armhf i386 loong64  mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 x32
+Architecture: amd64 arm64 armel armhf i386 loong64  mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 sw64 x32
 Depends: appstream,
          ${misc:Depends},
          ${shlibs:Depends}
@@ -211,7 +211,7 @@ Description: Qt5 library to access AppStream services (development files)
  software management tools which use the Qt5-based AppStream library.
 
 Package: libappstream-compose0
-Architecture: amd64 arm64 armel armhf i386 loong64  mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 x32
+Architecture: amd64 arm64 armel armhf i386 loong64  mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 sw64 x32
 Section: libs
 Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
@@ -230,7 +230,7 @@ Description: Building blocks to compose AppStream metadata
  icons, etc.).
 
 Package: libappstream-compose-dev
-Architecture: amd64 arm64 armel armhf i386 loong64 mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 x32
+Architecture: amd64 arm64 armel armhf i386 loong64 mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 sw64 x32
 Section: libdevel
 Multi-Arch: same
 Depends: gir1.2-appstreamcompose-1.0 (= ${binary:Version}),
@@ -253,7 +253,7 @@ Description: Building blocks to compose AppStream metadata (development files)
  using the AppStream compose library.
 
 Package: gir1.2-appstreamcompose-1.0
-Architecture: amd64 arm64 armel armhf i386 loong64 mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 x32
+Architecture: amd64 arm64 armel armhf i386 loong64 mips64el mipsel powerpc ppc64 ppc64el riscv64 s390x sparc64 sw64 x32
 Section: introspection
 Multi-Arch: same
 Depends: libappstream-compose0 (= ${binary:Version}),

--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@
 
 built_binaries := $(shell dh_listpackages)
 
-ifneq (,$(filter $(DEB_HOST_ARCH), amd64 arm64 armel armhf i386 loong64 mips64el mipsel ppc64el s390x powerpc ppc64 riscv64 sparc64 x32))
+ifneq (,$(filter $(DEB_HOST_ARCH), amd64 arm64 armel armhf i386 loong64 mips64el mipsel ppc64el s390x powerpc ppc64 riscv64 sparc64 sw64 x32))
 	ENABLE_COMPOSE=true
 else
 	ENABLE_COMPOSE=false


### PR DESCRIPTION
Add sw64 architecture support to appstream-compose, libappstream-compose0, libappstream-compose-dev, and gir1.2-appstreamcompose-1.0 packages.

Changes:
- Enable compose support on sw64 in debian/rules by adding sw64 to architecture list
- Add sw64 to Architecture field in debian/control for:
  - appstream-compose
  - libappstream-compose0
  - libappstream-compose-dev
  - gir1.2-appstreamcompose-1.0

Log:
- Enable compose support on sw64 in debian/rules
- Add sw64 to Architecture list for compose packages in debian/control

Influence:
- appstream-compose: new architecture sw64
- libappstream-compose0: new architecture sw64
- libappstream-compose-dev: new architecture sw64
- gir1.2-appstreamcompose-1.0: new architecture sw64
- debian/rules: sw64 added to compose-enabled architectures